### PR TITLE
chore: install Lucidchart APM package for architecture diagrams

### DIFF
--- a/.github/instructions/lucidchart.diagram-ops.instructions.md
+++ b/.github/instructions/lucidchart.diagram-ops.instructions.md
@@ -1,0 +1,28 @@
+---
+description: "Lucidchart diagram operations — search, retrieve, analyze, and generate diagrams via MCP"
+applyTo: "**"
+---
+
+# Lucidchart Diagram Operations
+
+When Lucid MCP tools are available, use them for:
+- Searching for diagrams using natural-language queries
+- Retrieving and reading existing diagram content and structure
+- Analyzing diagram elements, relationships, and layout
+- Generating new diagrams or modifying existing ones
+
+## Workflow
+
+1. **Search first** — use natural-language search to locate relevant diagrams before creating new ones. Avoid duplicating existing work.
+2. **Read before write** — retrieve and analyze an existing diagram's structure before making modifications.
+3. **Generate with intent** — when creating or modifying diagrams, provide clear descriptions of the desired elements, relationships, and layout.
+4. **Verify results** — after generating or modifying a diagram, retrieve it to confirm the changes match expectations.
+
+## Operating Rules
+
+- Prefer MCP lookups before writes when the user references diagrams by name or description.
+- Do not present Lucidchart behavior as package-owned functionality; this package delegates to Lucid's official MCP server.
+- Keep answers workflow-oriented and pragmatic instead of enumerating every upstream capability.
+- When a diagram task falls outside Lucidchart's capabilities, suggest alternative approaches rather than forcing the Lucid workflow.
+
+Load the **lucidchart.diagram-ops** skill for detailed guidance on diagram search, retrieval, analysis, and generation patterns.

--- a/.github/instructions/lucidchart.mcp-setup.instructions.md
+++ b/.github/instructions/lucidchart.mcp-setup.instructions.md
@@ -1,0 +1,29 @@
+---
+description: "Lucidchart MCP server connection and authentication setup"
+applyTo: "**"
+---
+
+# Lucidchart MCP Setup
+
+## Server Endpoint
+
+The Lucid MCP server is available at `https://mcp.lucid.app/mcp` and uses HTTP transport.
+
+After running `apm install` for this package, the MCP dependency is materialized in the local runtime. Verify the Lucid MCP tools are available before attempting diagram operations.
+
+## Authentication
+
+Lucidchart MCP requires workspace admin approval through the Lucid Marketplace:
+
+1. A workspace administrator must approve the Lucid MCP server integration in the Lucid Marketplace.
+2. Once approved, authentication is handled through the MCP connection flow — no separate API token is needed in most configurations.
+3. If the MCP tools are unavailable or return authorization errors, confirm that the workspace admin has completed the Marketplace approval step.
+
+## Pre-flight Checks
+
+Before any Lucidchart operation:
+- Confirm Lucid MCP tools are available in the current session.
+- If tools are missing, verify `apm install` has been run and the workspace admin has approved the integration.
+- If authorization errors occur, stop and guide the user to complete the Lucid Marketplace approval flow before retrying.
+
+Do not attempt diagram reads or writes until connectivity and authorization are confirmed.

--- a/.github/skills/lucidchartdiagram-ops/SKILL.md
+++ b/.github/skills/lucidchartdiagram-ops/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: lucidchart-diagram-ops
+description: Lucidchart diagram operations — search, retrieval, analysis, and generation patterns via Lucid MCP
+license: MIT
+---
+
+# Lucidchart Diagram Operations
+
+Use this skill when the task involves searching, retrieving, analyzing, or generating diagrams through Lucidchart's MCP integration.
+
+Do not treat this package as an implementation of Lucidchart features. It wires agents to Lucid Software's official MCP server so they can use upstream diagram workflows from the IDE.
+
+## Setup And Access First
+
+Before attempting Lucidchart actions, verify the runtime and authentication setup:
+- `apm install` has been run for the package so the MCP dependency is materialized in the local runtime.
+- The workspace administrator has approved the Lucid MCP server integration via the Lucid Marketplace.
+
+If Lucid MCP tools are unavailable or return authorization errors, resolve setup first instead of attempting diagram operations.
+
+## When To Use This Package
+
+Use Lucidchart MCP workflows for:
+- Searching existing diagrams by name, content, or natural-language description
+- Retrieving diagram structure, elements, and metadata
+- Analyzing relationships, flows, and layout of existing diagrams
+- Generating new diagrams from textual descriptions or requirements
+- Modifying existing diagram content, elements, or structure
+
+Avoid using it for:
+- Tasks that do not involve Lucidchart diagrams
+- Generating diagrams when a simpler text-based format (like Mermaid in Markdown) is sufficient
+- Speculating about Lucidchart internals that the MCP server does not expose
+
+## Workflow Guidance
+
+### 1. Search For Existing Diagrams
+
+Before creating a new diagram, search for existing ones that may already cover the topic.
+
+Use natural-language queries that describe the diagram's subject, purpose, or content. Be specific about the domain or system area to narrow results.
+
+### 2. Retrieve And Analyze Diagrams
+
+When working with an existing diagram:
+- Retrieve the full diagram structure to understand its current state
+- Identify the elements, connections, and layout before proposing changes
+- Note any naming conventions or organizational patterns already in use
+
+### 3. Generate New Diagrams
+
+When creating a new diagram:
+- Provide a clear description of the system, flow, or concept to visualize
+- Specify the diagram type when relevant (flowchart, sequence, architecture, ERD, etc.)
+- Include the key elements and their relationships
+- Describe the intended audience and level of detail
+
+### 4. Modify Existing Diagrams
+
+When updating an existing diagram:
+- Retrieve the current diagram state first
+- Describe changes in terms of what to add, remove, or reorganize
+- Preserve existing structure and conventions unless the user explicitly asks for reorganization
+
+## Diagram Type Guidance
+
+Common diagram types and when to use them:
+- **Architecture diagrams** — system components, services, and their interactions
+- **Flowcharts** — process flows, decision trees, and workflow steps
+- **Sequence diagrams** — time-ordered interactions between actors or services
+- **ERD (Entity-Relationship)** — data models and database schema relationships
+- **Network diagrams** — infrastructure topology and connectivity
+- **Org charts** — team structure and reporting relationships
+
+## Operating Notes
+
+This package targets Lucid Software's official MCP server at `https://mcp.lucid.app/mcp` (beta since November 2025).
+
+Keep package guidance focused on stable workflows the server supports: diagram search, retrieval, content analysis, and generation.

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,35 @@
+{
+  "servers": {
+    "com.microsoft/azure": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure/mcp",
+        "server",
+        "start"
+      ]
+    },
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp",
+      "headers": {}
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/x/all",
+      "headers": {}
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp",
+      "headers": {}
+    },
+    "lucid": {
+      "type": "http",
+      "url": "https://mcp.lucid.app/mcp",
+      "headers": {}
+    }
+  },
+  "inputs": []
+}

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -62,6 +62,17 @@ dependencies:
 - repo_url: epam-acme-bookstore-demo-org/agent-forge
   host: github.com
   resolved_commit: 9590f525054902844e9310be403da87467b46448
+  virtual_path: architecture/lucidchart
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .github/instructions/lucidchart.diagram-ops.instructions.md
+  - .github/instructions/lucidchart.mcp-setup.instructions.md
+  - .github/skills/lucidchartdiagram-ops
+  content_hash: sha256:1d0580f7299cce8821688a4db329863fdee7806aff72cf9d01f8e4ae70652c50
+- repo_url: epam-acme-bookstore-demo-org/agent-forge
+  host: github.com
+  resolved_commit: 9590f525054902844e9310be403da87467b46448
   virtual_path: backend/java/standards
   is_virtual: true
   depth: 2
@@ -217,6 +228,7 @@ dependencies:
 mcp_servers:
 - com.microsoft/azure
 - github
+- lucid
 - microsoft-learn
 mcp_configs:
   com.microsoft/azure:
@@ -226,6 +238,11 @@ mcp_configs:
     transport: http
     registry: false
     url: https://api.githubcopilot.com/mcp/x/all
+  lucid:
+    name: lucid
+    transport: http
+    registry: false
+    url: https://mcp.lucid.app/mcp
   microsoft-learn:
     name: microsoft-learn
     transport: http

--- a/apm.yml
+++ b/apm.yml
@@ -10,5 +10,6 @@ dependencies:
   - epam-acme-bookstore-demo-org/agent-forge/devops/docker
   - epam-acme-bookstore-demo-org/agent-forge/testing/testcontainers
   - epam-acme-bookstore-demo-org/agent-forge/devops/github
+  - epam-acme-bookstore-demo-org/agent-forge/architecture/lucidchart
   mcp: []
 scripts: {}


### PR DESCRIPTION
## Summary

Adds the `architecture/lucidchart` APM package to enable Lucidchart diagramming support for architecture documentation during the Java modernisation effort.

### Changes
- Added `epam-acme-bookstore-demo-org/agent-forge/architecture/lucidchart` dependency to `apm.yml`
- Integrated Lucidchart instructions and skills into `.github/`
- Configured Lucid MCP server

### Context
This is a prerequisite for the full modernisation plan which will include Azure Container Apps infrastructure architecture diagrams.