### PR TITLE
chore: remove Atlassian MCP server from VS Code config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -20,11 +20,6 @@
       "url": "https://api.githubcopilot.com/mcp/x/all",
       "headers": {}
     },
-    "atlassian": {
-      "type": "http",
-      "url": "https://mcp.atlassian.com/v1/mcp",
-      "headers": {}
-    },
     "lucid": {
       "type": "http",
       "url": "https://mcp.lucid.app/mcp",


### PR DESCRIPTION
Removes the Atlassian MCP server entry from `.vscode/mcp.json`.