### PR TITLE
docs: Add bidirectional issue tracking links to plan documents

### DIFF
--- a/docs/modernisation-plan/01-java-language-modernisation.md
+++ b/docs/modernisation-plan/01-java-language-modernisation.md
@@ -896,3 +896,58 @@ Goal:
 - This document should remain the reference for Java language modernization decisions.
 - Phase sequencing should be documented in [`05-migration-phases.md`](./05-migration-phases.md).
 - The main [`README.md`](../../README.md) should be reviewed separately for Java-version wording, because it still contains Java 8-era build guidance that can drift from the actual Java 21 baseline.
+
+---
+
+## Tracked Issues
+
+### Phase 0 — Foundation (Java standards)
+
+- [ ] #24 — Document Java 21 coding standards for OpenMRS Core
+- [ ] #33 — Update PR template and review checklist for modernisation work
+- [ ] #66 — Evaluate OpenRewrite for automated Java 21 migration
+- [ ] #70 — Update Spotless and Checkstyle configuration for Java 21 syntax
+
+### Phase 1 — Low-Risk Java Modernisation
+
+- [ ] #19 — Apply pattern matching instanceof — tools module
+- [ ] #16 — Apply pattern matching instanceof — test module
+- [ ] #21 — Apply pattern matching instanceof — liquibase module
+- [ ] #17 — Apply pattern matching instanceof — api module
+- [ ] #20 — Apply pattern matching instanceof — web module
+- [ ] #22 — Apply pattern matching instanceof — webapp module
+- [ ] #18 — Apply pattern matching instanceof — test-suite module
+- [ ] #39 — Adopt var for local variables — tools module
+- [ ] #35 — Adopt var for local variables — test module
+- [ ] #41 — Adopt var for local variables — liquibase module
+- [ ] #36 — Adopt var for local variables — api module
+- [ ] #37 — Adopt var for local variables — web module
+- [ ] #40 — Adopt var for local variables — webapp module
+- [ ] #38 — Adopt var for local variables — test-suite module
+- [ ] #56 — Convert switch statements to switch expressions — all modules
+- [ ] #58 — Adopt text blocks for multi-line strings — all modules
+- [ ] #55 — Adopt String API improvements (isBlank, strip, etc.) — all modules
+- [ ] #54 — Adopt Collections factory methods (List.of, Map.of) — all modules
+- [ ] #53 — Simplify try-with-resources patterns — all modules
+
+### Phase 3 — Medium-Risk Java Modernisation
+
+- [ ] #29 — Identify DTO and value object candidates for record conversion
+- [ ] #27 — Convert low-risk DTOs to records in internal modules
+- [ ] #26 — Convert DTOs to records in api module
+- [ ] #28 — Identify sealed class hierarchy candidates
+- [ ] #59 — Apply sealed class hierarchies to domain model
+- [ ] #62 — java.time migration — Phase A: Internal/private methods
+- [ ] #61 — java.time migration — Phase B: Add java.time overloads to public API
+- [ ] #60 — java.time migration — Phase C: Migrate callers module by module
+- [ ] #63 — java.time migration — Phase D: Remove deprecated Date-based methods
+- [ ] #76 — Modernise Stream API usage (.toList(), mapMulti()) — all modules
+- [ ] #77 — Prepare public API java.time migration proposal and versioning strategy
+
+### Phase 5 — High-Risk Changes
+
+- [ ] #34 — Investigate OpenmrsSecurityManager usage, callers, and module system impact
+- [ ] #81 — Design SecurityManager replacement model (propose StackWalker alternative)
+- [ ] #86 — Implement SecurityManager removal and approved replacement
+- [ ] #91 — Assess and migrate legacy HTTP client usage to java.net.http.HttpClient
+- [ ] #95 — Apply Optional API improvements (ifPresentOrElse, or, stream)

--- a/docs/modernisation-plan/02-containerisation.md
+++ b/docs/modernisation-plan/02-containerisation.md
@@ -596,3 +596,22 @@ This document intentionally leaves these decisions for follow-up work:
 - final ACA probe timings and scale rules
 
 Those should be resolved in the linked Azure infrastructure and migration planning documents.
+
+---
+
+## Tracked Issues
+
+### Phase 2 — Containerisation and Dev Environment
+
+- [ ] #14 — Switch production Docker image to JRE-only base
+- [ ] #25 — Add JVM container tuning flags (MaxRAMPercentage, G1GC)
+- [ ] #32 — Optimise Dockerfile layer caching and build performance
+- [ ] #43 — Add OCI standard labels and image metadata
+- [ ] #47 — Review and update .dockerignore
+- [ ] #65 — Configure container image vulnerability scanning
+- [ ] #69 — Create GitHub Actions container build workflow (build → test → scan → push)
+- [ ] #73 — Set up multi-platform builds with Docker Buildx (amd64 + arm64)
+- [ ] #94 — Create .env.example for docker-compose secrets management
+- [ ] #97 — Create docker-compose.test.yml for CI integration testing
+- [ ] #98 — Document image tagging and promotion strategy
+- [ ] #101 — Add VS Code Dev Container configuration

--- a/docs/modernisation-plan/03-azure-infrastructure.md
+++ b/docs/modernisation-plan/03-azure-infrastructure.md
@@ -725,3 +725,44 @@ Suggested labels:
 ## README drift note
 
 This plan introduces a new documentation area under `docs/modernisation-plan/`. If this Azure deployment approach becomes the primary recommended deployment path, the top-level [README.md](../../README.md) should be updated separately with links to this plan after human review.
+
+---
+
+## Tracked Issues
+
+### Phase 0 — Foundation (Azure)
+
+- [ ] #50 — Provision Azure subscription access and resource groups for dev and prod
+- [ ] #84 — Create Lucidchart architecture diagrams for Azure dev and production environments
+
+### Phase 2 — Dev Environment
+
+- [ ] #52 — Deploy Azure Container Registry (Basic SKU)
+- [ ] #80 — Deploy dev Container Apps Environment (Consumption plan) + MySQL Flexible Server
+- [ ] #83 — Deploy Azure Key Vault (dev) and seed secrets
+- [ ] #85 — Deploy OpenMRS Core Container App to dev environment
+
+### Phase 4 — Production Infrastructure
+
+- [ ] #51 — Provision production VNET (10.0.0.0/16) and subnet layout
+- [ ] #105 — Configure NSGs for all production subnets
+- [ ] #106 — Deploy production MySQL Flexible Server with private endpoint and HA
+- [ ] #107 — Deploy production Key Vault with private endpoint
+- [ ] #108 — Upgrade ACR to Standard SKU with private endpoint
+- [ ] #109 — Deploy Container Apps Environment into VNET (Workload profiles)
+- [ ] #110 — Deploy OpenMRS Container App with internal-only ingress
+- [ ] #111 — Deploy Application Gateway WAF_v2
+- [ ] #112 — Configure TLS termination and custom domain on Application Gateway
+- [ ] #113 — Configure managed identities and RBAC for Container App → Key Vault / ACR
+- [ ] #114 — Set up monitoring, alerting, and dashboards (App Insights + Log Analytics)
+- [ ] #115 — Enable Microsoft Defender for Containers and Database
+- [ ] #116 — Run production security hardening review and remediation
+- [ ] #117 — Create Bicep IaC modules for all production resources
+- [ ] #118 — Create infrastructure deployment GitHub Actions workflow (OIDC auth)
+- [ ] #119 — Create application deployment GitHub Actions workflow
+
+### Phase 6 — Go-Live (Azure)
+
+- [ ] #23 — Create DNS cutover and rollback plan for Azure go-live
+- [ ] #49 — Execute DNS cutover and go-live
+- [ ] #64 — Post-go-live monitoring — 48-hour intensive monitoring period

--- a/docs/modernisation-plan/04-testing-strategy.md
+++ b/docs/modernisation-plan/04-testing-strategy.md
@@ -399,3 +399,31 @@ The following gaps should be resolved as part of execution:
 - document the exact login and REST smoke-test fixtures and credentials strategy per environment
 
 Until those are finalised, the quality gates in this document should be treated as the minimum required direction.
+
+---
+
+## Tracked Issues
+
+### Phase 0 — Foundation (Testing)
+
+- [ ] #12 — Set up GitHub Actions CI pipeline for modernisation branches
+- [ ] #45 — Capture baseline test coverage, SpotBugs, startup, and latency metrics
+- [ ] #79 — Establish test coverage baseline with JaCoCo
+
+### Phase 2 — Dev Environment Validation
+
+- [ ] #89 — Create automated smoke test suite for post-deployment validation
+- [ ] #92 — Validate dev deployment end-to-end (health, DB, Liquibase, login)
+
+### Phase 3 — java.time Testing
+
+- [ ] #74 — Add serialization round-trip tests for java.time types
+
+### Phase 5 — Performance Benchmarking
+
+- [ ] #104 — Performance benchmarking — compare against Phase 0 baseline
+
+### Phase 6 — Go-Live Validation
+
+- [ ] #13 — Pre-production validation — full regression suite in staging
+- [ ] #42 — Load testing in production environment

--- a/docs/modernisation-plan/05-migration-phases.md
+++ b/docs/modernisation-plan/05-migration-phases.md
@@ -585,3 +585,21 @@ Examples:
 - [02-containerisation.md](./02-containerisation.md)
 - [03-azure-infrastructure.md](./03-azure-infrastructure.md)
 - [04-testing-strategy.md](./04-testing-strategy.md)
+
+---
+
+## Tracked Issues
+
+### Cross-Phase Tracking
+
+- [ ] #88 — Create Lucidchart phase dependency and CI/CD pipeline diagrams
+- [ ] #57 — Phase 1 rollout tracking and merge readiness review
+- [ ] #75 — Create and maintain Phase 3 java.time migration tracker
+- [ ] #100 — Remove transitional deprecated APIs introduced during modernisation
+
+### Phase 6 — Go-Live
+
+- [ ] #31 — Assess and execute application data migration requirements
+- [ ] #46 — Validate blue-green deployment process for production cutover
+- [ ] #68 — Write and review deployment, rollback, and incident runbooks
+- [ ] #72 — Retrospective and lessons learned

--- a/docs/modernisation-plan/07-code-quality-enhancement.md
+++ b/docs/modernisation-plan/07-code-quality-enhancement.md
@@ -197,3 +197,31 @@ The following prompts from the `performance-code-quality` skill should be used d
 | P1.5-13 | Audit and remove dead `@Deprecated` code | Task | `modernisation`, `java-21`, `phase-1.5`, `priority-3` | P3 |
 | P1.5-14 | Flatten deeply nested methods (>3 levels) in top 10 files | Task | `modernisation`, `java-21`, `phase-1.5`, `priority-3` | P3 |
 | P1.5-15 | Refactor methods with 5+ parameters into config objects | Task | `modernisation`, `java-21`, `phase-1.5`, `priority-3` | P3 |
+
+---
+
+## Tracked Issues
+
+### Priority 1 — Error Handling Hardening
+
+- [ ] #15 — Error handling hardening — api module (256 broad catches)
+- [ ] #30 — Error handling hardening — web module
+- [ ] #44 — Remove silent exception swallowing (71 catch blocks)
+
+### Priority 2 — God Class Decomposition
+
+- [ ] #48 — Decompose OpenmrsUtil.java (2,160 lines)
+- [ ] #67 — Decompose HibernateConceptDAO.java (2,405 lines)
+- [ ] #71 — Decompose ConceptServiceImpl.java (2,343 lines)
+- [ ] #78 — Decompose InitializationFilter.java (1,985 lines)
+- [ ] #82 — Decompose ModuleFactory.java (1,597 lines)
+- [ ] #87 — Decompose remaining god classes (Context, ORUR01Handler, OrderServiceImpl, PatientServiceImpl, ModuleUtil)
+
+### Priority 3 — Complexity Reduction
+
+- [ ] #90 — Audit and eliminate boolean flag parameters in public API
+- [ ] #93 — Convert string switch dispatch to enum-based dispatch
+- [ ] #96 — Audit and resolve @SuppressWarnings annotations
+- [ ] #99 — Audit and remove dead @Deprecated code
+- [ ] #102 — Flatten deeply nested methods (>3 levels) in top 10 files
+- [ ] #103 — Refactor methods with 5+ parameters into config objects


### PR DESCRIPTION
## Summary

Adds `Tracked Issues` sections with GitHub task lists (`- [ ] #NN`) to all 6 plan documents, creating **bidirectional links** between the markdown files and the 108 GitHub Issues in the modernisation backlog.

### How it works

GitHub natively renders task list issue references as "Tracked in <file>" on each issue's page. This creates a two-way navigation:
- **Doc → Issues**: Each plan document lists its related issues with checkboxes
- **Issues → Doc**: Each issue shows which plan document tracks it

### Changes

| Document | Issues Linked |
|---|---|
| `01-java-language-modernisation.md` | 39 |
| `02-containerisation.md` | 12 |
| `03-azure-infrastructure.md` | 25 |
| `04-testing-strategy.md` | 9 |
| `05-migration-phases.md` | 8 |
| `07-code-quality-enhancement.md` | 15 |
| **Total** | **108** |